### PR TITLE
Set max warnings to error if there are any many warnings

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -2,7 +2,7 @@
   "name": "cruzhacks-2022-backend",
   "description": "Firebase functions for CruzHacks 2022 main site",
   "scripts": {
-    "lint": "eslint .",
+    "lint": "eslint . --max-warnings=0",
     "serve": "firebase emulators:start",
     "shell": "firebase functions:shell",
     "start": "yarn run shell",


### PR DESCRIPTION
Problem
=======
What problem or issue does this pull request solve [Jira](https://cruzhacks-dev.atlassian.net/jira/software/c/projects/C2D/issues/
C2D-55


Solution
========
What I/we did to solve this problem
* Ensures that the linter will return an error if there are any warnings


Change Summary:
---------------
* Added max-warning limit


Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] GCP Secret Manager (Both development and production)

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images 