### PR TITLE
Bug/consistent field

### DIFF
--- a/functions/__tests__/announcements-api/getAllAnnouncements/index.test.js
+++ b/functions/__tests__/announcements-api/getAllAnnouncements/index.test.js
@@ -39,13 +39,13 @@ describe("Testing Get All Announcements", () => {
         {
           id: "id",
           data: function () {
-            return { title: "title", message: "message", timeStamp: "today" };
+            return { title: "title", message: "message", date: "today" };
           },
         },
         {
           id: "id2",
           data: function () {
-            return { title: "title2", message: "message2", timeStamp: "tomorrow" };
+            return { title: "title2", message: "message2", date: "tomorrow" };
           },
         },
       ]),
@@ -54,7 +54,7 @@ describe("Testing Get All Announcements", () => {
     expect(response.statusCode).toBe(200);
     expect(response.body.message).toBe("Request success, announcements retrieved");
     expect(response.body.announcements).toBe(
-      '[{"id":"id","title":"title","message":"message","timeStamp":"today"},{"id":"id2","title":"title2","message":"message2","timeStamp":"tomorrow"}]',
+      '[{"id":"id","title":"title","message":"message","date":"today"},{"id":"id2","title":"title2","message":"message2","date":"tomorrow"}]',
     );
     expect(response.body.count).toBe(2);
   });

--- a/functions/controllers/announcements-api/index.js
+++ b/functions/controllers/announcements-api/index.js
@@ -19,12 +19,12 @@ announcements.use(express.json());
 
 announcements.get("/", validKey, async (req, res) => {
   try {
-    const snapshot = await queryCollectionSorted("announcements", "timeStamp");
+    const snapshot = await queryCollectionSorted("announcements", "date", 4);
     const documents = [];
     snapshot.forEach((doc) => {
       const id = doc.id;
       const data = doc.data();
-      documents.push({ id: id, title: data.title, message: data.message, timeStamp: data.timeStamp });
+      documents.push({ id: id, title: data.title, message: data.message, date: data.date });
     });
     return res.status(200).send({
       error: false,

--- a/functions/controllers/announcements-api/index.js
+++ b/functions/controllers/announcements-api/index.js
@@ -63,10 +63,10 @@ announcements.delete("/:id", jwtCheck, hasDeleteAnnouncement, async (req, res) =
 
 announcements.post("/", jwtCheck, hasUpdateAnnouncement, async (req, res) => {
   const { title, message } = req.body;
-  if (!title || title.length > 50 || !/^[a-zA-Z0-9 ]+$/.test(title)) {
+  if (!title || title.length > 25 || !/^[a-zA-Z0-9 ]+$/.test(title)) {
     return res.status(400).send({ error: true, status: 400, message: "Invalid title" });
   }
-  if (!message || message.length > 200 || !/^[a-zA-Z0-9 ]+$/.test(message)) {
+  if (!message || message.length > 100 || !/^[a-zA-Z0-9 ]+$/.test(message)) {
     return res.status(400).send({ error: true, status: 400, message: "Invalid Message" });
   }
   const data = { title: title, message: message, date: Date.now() };

--- a/functions/utils/database.js
+++ b/functions/utils/database.js
@@ -19,7 +19,7 @@ const queryCollection = (collection) => {
 const queryCollectionSorted = (collection, opt, limit) => {
   // returns sorted in ascending order
   // opt must be a string and it must be a doc field
-  return db.collection(collection).orderBy(opt).limit(limit).get();
+  return db.collection(collection).orderBy(opt, "desc").limit(limit).get();
 };
 
 const deleteDocument = (collection, id) => {

--- a/functions/utils/database.js
+++ b/functions/utils/database.js
@@ -16,10 +16,10 @@ const queryCollection = (collection) => {
   return db.collection(collection).get();
 };
 
-const queryCollectionSorted = (collection, opt) => {
+const queryCollectionSorted = (collection, opt, limit) => {
   // returns sorted in ascending order
   // opt must be a string and it must be a doc field
-  return db.collection(collection).orderBy(opt).get();
+  return db.collection(collection).orderBy(opt).limit(limit).get();
 };
 
 const deleteDocument = (collection, id) => {


### PR DESCRIPTION
Problem
=======
* The announcements API has an inconsistency between the field names on what is being stored and what is being retrieved and the querying if affected by this as well



Solution
========
What I/we did to solve this problem
* Fixed the querying with a descending, added limit to prevent high costs
* Consistent naming


Change Summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] GCP Secret Manager (Both development and production)

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images 