### PR TITLE
Update status code for GET `/analytics`

### DIFF
--- a/functions/__tests__/application/analytics/index.test.js
+++ b/functions/__tests__/application/analytics/index.test.js
@@ -31,7 +31,7 @@ describe("Analytics test", () => {
   });
 
   it("Should return analytics", async (done) => {
-    fakeDoc = makeDocumentSnapshot({
+    const fakeDoc = makeDocumentSnapshot({
       applicantCount: 100,
       firstTimeCount: 100,
       ucscStudentCount: 100,

--- a/functions/controllers/application/index.js
+++ b/functions/controllers/application/index.js
@@ -100,7 +100,7 @@ application.get("/checkApp", jwtCheck, hasReadApp, async (req, res) => {
     res.status(200).send({ code: 200, status: appStatus, exists: true, message: "Document Found" });
   } catch (error) {
     if (error.message === "No Document") {
-      res.status(200).send({ code: 200, status: "No Document", exists: false, message: "No Document" });
+      res.status(200).send({ code: 404, status: "No Document", exists: false, message: "No Document" });
     } else {
       res.status(500).send({ code: 500, status: "No Document", exists: false, message: "Internal Server Error" });
     }
@@ -111,8 +111,9 @@ application.get("/analytics", jwtCheck, hasReadAnalytics, async (req, res) => {
   try {
     const analyticsSnapshot = await queryDocument("analytics", "applicant-analytics");
     if (!analyticsSnapshot.exists) {
-      throw "No Doc";
+      throw new Error("No Document");
     }
+
     res.status(201).send({
       message: {
         applicantCount: analyticsSnapshot.get("applicantCount"),
@@ -120,9 +121,9 @@ application.get("/analytics", jwtCheck, hasReadAnalytics, async (req, res) => {
         ucscApplicants: analyticsSnapshot.get("ucscStudentCount"),
       },
     });
-  } catch (err) {
-    if (err === "No Doc") {
-      res.status(404).send({ status: 404, message: "No Document" });
+  } catch (error) {
+    if (error.message === "No Document") {
+      res.status(200).send({ status: 404, message: "No Document" });
     }
     res.status(500).send({ status: 500, message: "Insufficient Permissions" });
   }

--- a/functions/controllers/application/index.js
+++ b/functions/controllers/application/index.js
@@ -92,7 +92,7 @@ application.post("/submit", jwtCheck, hasUpdateApp, async (req, res) => {
 
 application.get("/checkApp", jwtCheck, hasReadApp, async (req, res) => {
   try {
-    doc = await queryDocument("applicants", req.user.sub);
+    const doc = await queryDocument("applicants", req.user.sub);
     const appStatus = doc.get("status");
     if (appStatus === undefined) {
       throw new Error("No Document");
@@ -100,7 +100,7 @@ application.get("/checkApp", jwtCheck, hasReadApp, async (req, res) => {
     res.status(200).send({ code: 200, status: appStatus, exists: true, message: "Document Found" });
   } catch (error) {
     if (error.message === "No Document") {
-      res.status(200).send({ code: 404, status: "No Document", exists: false, message: "No Document" });
+      res.status(200).send({ code: 200, status: "No Document", exists: false, message: "No Document" });
     } else {
       res.status(500).send({ code: 500, status: "No Document", exists: false, message: "Internal Server Error" });
     }
@@ -115,6 +115,7 @@ application.get("/analytics", jwtCheck, hasReadAnalytics, async (req, res) => {
     }
 
     res.status(201).send({
+      status: 201,
       message: {
         applicantCount: analyticsSnapshot.get("applicantCount"),
         firstTime: analyticsSnapshot.get("firstTimeCount"),
@@ -123,7 +124,7 @@ application.get("/analytics", jwtCheck, hasReadAnalytics, async (req, res) => {
     });
   } catch (error) {
     if (error.message === "No Document") {
-      res.status(200).send({ status: 404, message: "No Document" });
+      res.status(200).send({ status: 200, message: "No Document" });
     }
     res.status(500).send({ status: 500, message: "Insufficient Permissions" });
   }


### PR DESCRIPTION
Problem
=======
If there're no applicants, should we really set the HTTP status to 404? I don't like how google chrome prints an ugly message when a 404 status code is received.

Solution
========
What I/we did to solve this problem
* 


Change Summary:
---------------
* Tidy, well formulated commit message
* Another great commit message
* Something else I/we did

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] GCP Secret Manager (Both development and production)

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images 