### PR TITLE
Updating Regex to support \r\n

### DIFF
--- a/functions/__tests__/utils/regex/index.test.js
+++ b/functions/__tests__/utils/regex/index.test.js
@@ -96,6 +96,9 @@ describe("Testing alphanumeric with punctuation and newline Regex", () => {
       ),
     ).toBe(false);
   });
+  it("Should pass given \r\n", () => {
+    expect(alphanumericPunctuationRegexWithNewLine("test\r\n")).toBe(false);
+  });
   it("Should fail given paragraph with invalid symbols", () => {
     expect(
       alphanumericPunctuationRegexWithNewLine(

--- a/functions/controllers/application/index.js
+++ b/functions/controllers/application/index.js
@@ -39,10 +39,12 @@ application.post("/submit", jwtCheck, hasUpdateApp, async (req, res) => {
     }
     const appData = createAppObject(fields);
     if (appData === null) {
+      functions.logger.log("Form Error on Create");
       return res.status(400).send({ code: 400, message: "Form Validation Failed", errors: isValidData });
     }
     const isValidData = validateAppData(appData);
     if (isValidData.length > 0) {
+      functions.logger.log(appData);
       functions.logger.log(req.user.sub + " Validation Errors " + isValidData);
       return res.status(400).send({ code: 400, message: "Form Validation Failed", errors: isValidData });
     }

--- a/functions/utils/application.js
+++ b/functions/utils/application.js
@@ -85,20 +85,20 @@ const createAppObject = (body) => {
       country: body["country"] ? body["country"] : "",
 
       // Short Answer
-      whyCruzHacks: body["whyCruzHacks"] ? body["whyCruzHacks"] : "",
-      newThisYear: body["newThisYear"] ? body["newThisYear"] : "",
-      grandestInvention: body["grandestInvention"] ? body["grandestInvention"] : "",
+      whyCruzHacks: body["whyCruzHacks"] ? body["whyCruzHacks"].replace(/(\r\n|\n|\r)/gm, " ") : "",
+      newThisYear: body["newThisYear"] ? body["newThisYear"].replace(/(\r\n|\n|\r)/gm, " ") : "",
+      grandestInvention: body["grandestInvention"] ? body["grandestInvention"].replace(/(\r\n|\n|\r)/gm, " ") : "",
 
       // Prior Experience
       firstCruzHack: body["firstCruzHack"] ? body["firstCruzHack"].toLowerCase() === "yes" : false,
       hackathonCount: body["hackathonCount"] ? parseInt(body["hackathonCount"]) : -1,
-      priorExperience: body["priorExperience"] ? body["priorExperience"] : "",
+      priorExperience: body["priorExperience"] ? body["priorExperience"].replace(/(\r\n|\n|\r)/gm, " ") : "",
 
       // Connected
       linkedin: body["linkedin"] ? body["linkedin"] : "",
       github: body["github"] ? body["github"] : "",
-      cruzCoins: body["cruzCoins"] ? body["cruzCoins"] : "",
-      anythingElse: body["anythingElse"] ? body["anythingElse"] : "",
+      cruzCoins: body["cruzCoins"] ? body["cruzCoins"].replace(/(\r\n|\n|\r)/gm, " ") : "",
+      anythingElse: body["anythingElse"] ? body["anythingElse"].replace(/(\r\n|\n|\r)/gm, " ") : "",
     };
     return appObj;
   } catch (error) {

--- a/functions/utils/regex.js
+++ b/functions/utils/regex.js
@@ -11,7 +11,7 @@ const alphanumericPunctuationRegex = (message) => {
 };
 
 const alphanumericPunctuationRegexWithNewLine = (message) => {
-  return !/^[\x20-\x7E\n]*$/.test(message);
+  return !/^[\x20-\x7E\r?\n]*$/.test(message);
 };
 
 const emailRegex = (email) => {


### PR DESCRIPTION
Problem
=======
Server Validation is slightly incorrect whenever the client sends to the server a replaced string of \r\n.



Solution
========
What I/we did to solve this problem
* Updated Regex to read \r\n or \n and replace with empty space


Change Summary:
---------------
* Updated Regex tests to validate change is effective
* Updated Regex to support \r\n
* Added Logger on Error to AppObj to see if other regex issues occur in the future

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] GCP Secret Manager (Both development and production)

Images/Important Notes (optional):
-----------------------
* Insert any notes/issues, dependencies added or removed, or images 