### PR TITLE
Separating checkApp into it's own endpoint, Updating Admin import

### DIFF
--- a/functions/__tests__/application/checkapp/index.test.js
+++ b/functions/__tests__/application/checkapp/index.test.js
@@ -1,6 +1,6 @@
 const testConfig = require("firebase-functions-test")();
 const request = require("supertest");
-const { application } = require("../../../controllers/application/index");
+const { application } = require("../../../controllers/viewApp/index");
 const { jwtCheck, hasReadApp } = require("../../../utils/middleware");
 const { queryDocument } = require("../../../utils/database");
 const { makeDocumentSnapshot } = require("firebase-functions-test/lib/providers/firestore");

--- a/functions/__tests__/application/submit/index.test.js
+++ b/functions/__tests__/application/submit/index.test.js
@@ -2,7 +2,8 @@ const testConfig = require("firebase-functions-test")();
 const request = require("supertest");
 const { application } = require("../../../controllers/application/index");
 const { jwtCheck, hasUpdateApp } = require("../../../utils/middleware");
-const { setDocument, uploadFile } = require("../../../utils/database");
+const { setDocument } = require("../../../utils/database");
+const { uploadFile } = require("../../../utils/storage");
 const { isValidFileData, getNewFileName } = require("../../../utils/application");
 
 const pdf500kb = "__tests__/application/submit/500kb.pdf";
@@ -23,6 +24,7 @@ testConfig.mockConfig({
 
 jest.mock("../../../utils/middleware");
 jest.mock("../../../utils/database");
+jest.mock("../../../utils/storage");
 jest.mock("../../../utils/application", () => ({
   ...jest.requireActual("../../../utils/application"),
   isValidFileData: jest.fn(),

--- a/functions/controllers/viewApp/index.js
+++ b/functions/controllers/viewApp/index.js
@@ -1,0 +1,44 @@
+const functions = require("firebase-functions");
+const express = require("express");
+const cors = require("cors");
+
+const { jwtCheck, hasReadApp } = require("../../utils/middleware");
+const { queryDocument } = require("../../utils/database");
+const admin = require("firebase-admin");
+admin.initializeApp();
+firedb = admin.firestore();
+
+const application = express();
+application.disable("x-powered-by");
+application.use(express.json());
+
+const auth0Config = functions.config().auth;
+const corsConfig = auth0Config ? auth0Config.cors : "";
+
+const corsOptions = {
+  origin: corsConfig,
+  optionsSuccessStatus: 200,
+};
+
+application.use(cors(corsOptions));
+
+application.get("/checkApp", jwtCheck, hasReadApp, async (req, res) => {
+  try {
+    const doc = await queryDocument("applicants", req.user.sub);
+    const appStatus = doc.get("status");
+    if (appStatus === undefined) {
+      throw new Error("No Document");
+    }
+    res.status(200).send({ code: 200, status: appStatus, exists: true, message: "Document Found" });
+  } catch (error) {
+    if (error.message === "No Document") {
+      res.status(200).send({ code: 200, status: "No Document", exists: false, message: "No Document" });
+    } else {
+      res.status(500).send({ code: 500, status: "No Document", exists: false, message: "Internal Server Error" });
+    }
+  }
+});
+
+const service = functions.https.onRequest(application);
+
+module.exports = { application, service };

--- a/functions/controllers/viewApp/index.js
+++ b/functions/controllers/viewApp/index.js
@@ -24,7 +24,7 @@ application.use(cors(corsOptions));
 
 application.get("/checkApp", jwtCheck, hasReadApp, async (req, res) => {
   try {
-    const doc = await queryDocument("applicants", req.user.sub);
+    const doc = await queryDocument(firedb, "applicants", req.user.sub);
     const appStatus = doc.get("status");
     if (appStatus === undefined) {
       throw new Error("No Document");

--- a/functions/index.js
+++ b/functions/index.js
@@ -11,6 +11,9 @@ if (!function_name || function_name === "announcements") {
 if (!function_name || function_name === "application") {
   exports.application = require("./controllers/application/index").service;
 }
+if (!function_name || function_name === "viewApp") {
+  exports.viewApp = require("./controllers/viewApp/index").service;
+}
 if (!function_name || function_name === "writeToAnalytics") {
   exports.writeToAnalytics = require("./utils/analytics").service;
 }

--- a/functions/package.json
+++ b/functions/package.json
@@ -6,8 +6,8 @@
     "serve": "firebase emulators:start",
     "shell": "firebase functions:shell",
     "start": "yarn run shell",
-    "deploy:dev": "firebase deploy --only functions:auth,functions:verifyRecaptcha,functions:announcements,functions:application,functions:writeToAnalytics -P default",
-    "deploy:prod": "firebase deploy --only functions:auth,functions:verifyRecaptcha,functions:announcements,functions:application,functions:writeToAnalytics -P production",
+    "deploy:dev": "firebase deploy --only functions:auth,functions:verifyRecaptcha,functions:announcements,functions:application,functions:viewApp,functions:writeToAnalytics -P default",
+    "deploy:prod": "firebase deploy --only functions:auth,functions:verifyRecaptcha,functions:announcements,functions:application,functions:viewApp,functions:writeToAnalytics -P production",
     "logs": "firebase functions:log",
     "test": "jest --watchAll",
     "test:ci": "jest --ci --color --runInBand --silent"

--- a/functions/utils/admin.js
+++ b/functions/utils/admin.js
@@ -1,6 +1,0 @@
-const admin = require("firebase-admin");
-admin.initializeApp();
-db = admin.firestore();
-storage = admin.storage();
-
-module.exports = { db, admin, storage };

--- a/functions/utils/analytics.js
+++ b/functions/utils/analytics.js
@@ -1,5 +1,7 @@
 const functions = require("firebase-functions");
-const { db, admin } = require("./admin");
+const admin = require("firebase-admin");
+admin.initializeApp();
+db = admin.firestore();
 
 /*
     writeToAnalytics adds an event trigger to 'applicants' collection.

--- a/functions/utils/database.js
+++ b/functions/utils/database.js
@@ -1,36 +1,27 @@
-require("./admin");
-
-const addDocument = (collection, document) => {
+const addDocument = (db, collection, document) => {
   return db.collection(collection).add(document);
 };
 
-const queryDocument = (collection, id) => {
+const queryDocument = (db, collection, id) => {
   return db.collection(collection).doc(id).get();
 };
 
-const setDocument = (collection, id, fields) => {
+const setDocument = (db, collection, id, fields) => {
   return db.collection(collection).doc(id).set(fields);
 };
 
-const queryCollection = (collection) => {
+const queryCollection = (db, collection) => {
   return db.collection(collection).get();
 };
 
-const queryCollectionSorted = (collection, opt, limit) => {
+const queryCollectionSorted = (db, collection, opt, limit) => {
   // returns sorted in ascending order
   // opt must be a string and it must be a doc field
   return db.collection(collection).orderBy(opt, "desc").limit(limit).get();
 };
 
-const deleteDocument = (collection, id) => {
+const deleteDocument = (db, collection, id) => {
   return db.collection(collection).doc(id).delete();
-};
-
-const uploadFile = (bucketName, filename, file) => {
-  const bucket = storage.bucket(bucketName);
-  return bucket.upload(file.path, {
-    destination: filename,
-  });
 };
 
 module.exports = {
@@ -40,5 +31,4 @@ module.exports = {
   queryCollection,
   queryCollectionSorted,
   deleteDocument,
-  uploadFile,
 };


### PR DESCRIPTION
Problem
=======
Check App has been taking 4-5 seconds on Cold Start to run, most likely to loading cloud storage and other endpoint functions.



Solution
========
What I/we did to solve this problem
* Separating into it's own endpoint so we don't need to load cloud storage all the time when using database commands.


Change Summary:
---------------
* Updated all database + cloud storage functions to take in db/storage as parameter
* Updated checkApp to be it's own separate endpoint (less loading, won't need to load storage)

Dev-Ops
=======
If you added an ENV variable, please check off that you've updated the following  
- [ ] GCP Secret Manager (Both development and production)

Images/Important Notes (optional):
-----------------------
* Potential downside, this might cause the submit endpoint to run in a cold started scenario since checkApp won't be able to create an instance for it
* I made these changes but let's check-in on this after this week's review